### PR TITLE
feat: support node addons files

### DIFF
--- a/scripts/pack-plugin.js
+++ b/scripts/pack-plugin.js
@@ -63,7 +63,8 @@ async function packPlugin() {
       'LICENSE',
       'icon.png',
       'icon.ico',
-      'assets/**/*'
+      'assets/**/*',
+      'dist/*.node'
     ]
 
     // Copy files


### PR DESCRIPTION
[Node addons](https://nodejs.org/api/addons.html) are a powerful tool that allow developers to implement native functions through Node.
When I was developing my plugin, I found that the current SDK does not support packaging this type of files resulting me have to do a manually copy.
It would be better if the SDK supports this kind of files on its own.